### PR TITLE
feat(ArticleUrl): fixes bug that listing urls could not be parsed

### DIFF
--- a/Shared/articles/domain/ArticleUrl.swift
+++ b/Shared/articles/domain/ArticleUrl.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct ArticleUrl {
-  private static let pathRegexString = #"^(http(s)?:\/\/)?dev.to\/(?<path>[a-zA-z\d]*\/[a-zA-Z\-\d]*)$"#
+  private static let pathRegexString = #"^(http(s)?:\/\/)?dev.to\/(?<path>[a-zA-z\d-]*\/[a-zA-Z\-\d]*)$"#
 
   let url: String
   let path: String?


### PR DESCRIPTION
Regex did not allow for "_" in user/listing name